### PR TITLE
Firebase local emulator configuration, .gitinore entries and Node upgrade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+# macOS
+**/.DS_Store
+
+# javascript
+**/.env
+
+# node
+**/node_modules/*
+**/npm-debug.log
+
+# firebase
+**/ui-debug.log
+**/database-debug.log
+**/firebase-debug.log
+**/firestore-debug.log
+**/package-lock.json
+**/.runtimeconfig.json

--- a/firebase.json
+++ b/firebase.json
@@ -1,1 +1,13 @@
-{}
+{
+  "emulators": {
+    "functions": {
+      "port": 5001
+    },
+    "firestore": {
+      "port": 8080
+    },
+    "ui": {
+      "enabled": true
+    }
+  }
+}

--- a/functions/.gitignore
+++ b/functions/.gitignore
@@ -1,1 +1,0 @@
-node_modules/

--- a/functions/index.js
+++ b/functions/index.js
@@ -7,8 +7,4 @@ app.get("/", (req, res) => {
   res.send("Play Date Scheduler");
 });
 
-app.listen(port, () => {
-  console.log(`Example app listening on port ${port}`);
-});
-
 exports.app = functions.region("europe-west2").https.onRequest(app);

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -13,7 +13,7 @@
         "firebase-functions-test": "^0.2.0"
       },
       "engines": {
-        "node": "16"
+        "node": "10"
       }
     },
     "node_modules/@fastify/busboy": {

--- a/functions/package.json
+++ b/functions/package.json
@@ -9,7 +9,7 @@
     "logs": "firebase functions:log"
   },
   "engines": {
-    "node": "10"
+    "node": "16"
   },
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
- Added some configuration to the firebase.json file to launch an emulated version of Firebase Functions and Firestore on our local machines.
- Moved .gitignore to the root directory and added various Firebase log files that we wouldn't want pushed to Git.
- Updated node 10 to node 16, node 10 isn't supported anymore